### PR TITLE
Expose the original ImportError

### DIFF
--- a/deckweaver/__init__.py
+++ b/deckweaver/__init__.py
@@ -4,7 +4,9 @@ try:
     from . import _core
 except ImportError as exc:
     raise ImportError(
-        "deckweaver._core is not built. Build with `./build.sh release` or `pip install .`."
+        f"deckweaver._core is not built. "
+        f"Build with `./build.sh release` or `pip install .`. "
+        f"Original error: {exc}"
     ) from exc
 
 # Re-export public API


### PR DESCRIPTION
This change simply re-exposes the ImportError if loading the core fails. It's primarily for situations where the _core may exist, but cannot be loaded for other reasons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging to provide clearer guidance when dependencies fail to load, including actionable troubleshooting steps for resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/designgears/DeckWeaver/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->