### PR TITLE
Action to rebuild the _core lib under ubuntu 24.04 on release

### DIFF
--- a/.github/workflows/update-lib.yml
+++ b/.github/workflows/update-lib.yml
@@ -1,0 +1,51 @@
+name: Build Core Library
+
+on:
+  push:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    # Only run on a chore(release) commit, and make sure we don't loop ourselves around
+    if: |
+      startsWith(github.event.head_commit.message, 'chore(release)') &&
+      github.actor != 'github-actions[bot]'
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      ## Pull in Python
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      ## Pull in Rust
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      ## Run the build script
+      - name: Run update script
+        run: |
+          bash ./build.sh release
+
+      ## Push the file to the repo
+      - name: Commit updated files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add deckweaver/_core.abi3.so
+
+          # Skip commit if nothing changed
+          git diff --cached --quiet && exit 0
+
+          git commit -m "${{ github.event.head_commit.message }}"
+          git push


### PR DESCRIPTION
There's currently an issue with DeckWeaver where the manual build of `_core.abi3.so` can result in some distros / environments (including flatpaks) failing to load it due to it having a higher GLIBC requirement than is currently available in the runtime environment. This workflow should help mitigate that problem.

Every time a push comes through with the latest commit starting with `chore(release)` this workflow will run.

The workflow checks out the code, runs the build script, then commits and pushes a new `deckweaver/_core.abi3.so` built under Ubuntu 24.04 to help ensure maximum compatibility across distros.

Edit, fixes: #12 